### PR TITLE
Add SwiftUI iOS client

### DIFF
--- a/ios-app/ApiService.swift
+++ b/ios-app/ApiService.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+final class ApiService {
+    static let shared = ApiService()
+    private init() {}
+
+    private let baseURL = URL(string: "http://localhost:5000")!
+
+    func fetchTodos() async -> [Todo] {
+        guard let url = URL(string: "/api/todos", relativeTo: baseURL) else {
+            return []
+        }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let todos = try JSONDecoder().decode([Todo].self, from: data)
+            return todos
+        } catch {
+            print("Fetch todos failed: \(error)")
+            return []
+        }
+    }
+
+    func fetchPosts() async -> [Post] {
+        guard let url = URL(string: "/api/posts", relativeTo: baseURL) else {
+            return []
+        }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let posts = try JSONDecoder().decode([Post].self, from: data)
+            return posts
+        } catch {
+            print("Fetch posts failed: \(error)")
+            return []
+        }
+    }
+}

--- a/ios-app/ContentView.swift
+++ b/ios-app/ContentView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var isLoggedIn = false
+
+    var body: some View {
+        NavigationView {
+            if isLoggedIn {
+                DashboardView()
+            } else {
+                LoginView(onLogin: {
+                    self.isLoggedIn = true
+                })
+            }
+        }
+    }
+}
+
+struct DashboardView: View {
+    var body: some View {
+        List {
+            NavigationLink("Todos", destination: TodoListView())
+            NavigationLink("Forum", destination: ForumView())
+        }
+        .navigationTitle("Dashboard")
+    }
+}
+
+struct LoginView: View {
+    var onLogin: () -> Void
+    @State private var username = ""
+    @State private var password = ""
+    var body: some View {
+        VStack {
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            Button("Login") {
+                // TODO: Perform actual login via API
+                onLogin()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .navigationTitle("Login")
+    }
+}
+
+struct TodoListView: View {
+    @State private var todos: [Todo] = []
+    var body: some View {
+        List(todos) { todo in
+            HStack {
+                Image(systemName: todo.completed ? "checkmark.circle.fill" : "circle")
+                Text(todo.task)
+            }
+        }
+        .navigationTitle("Todos")
+        .onAppear {
+            Task {
+                todos = await ApiService.shared.fetchTodos()
+            }
+        }
+    }
+}
+
+struct ForumView: View {
+    @State private var posts: [Post] = []
+    var body: some View {
+        List(posts) { post in
+            VStack(alignment: .leading) {
+                Text(post.author)
+                    .font(.headline)
+                Text(post.content)
+                HStack {
+                    Label("\(post.likeCount)", systemImage: "hand.thumbsup")
+                    Label("\(post.complaintCount)", systemImage: "flag")
+                }
+                .font(.caption)
+            }
+        }
+        .navigationTitle("Forum")
+        .onAppear {
+            Task {
+                posts = await ApiService.shared.fetchPosts()
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios-app/FirstProgramApp.swift
+++ b/ios-app/FirstProgramApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FirstProgramApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios-app/Models.swift
+++ b/ios-app/Models.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Todo: Identifiable, Decodable {
+    let id: Int
+    let task: String
+    let completed: Bool
+}
+
+struct Post: Identifiable, Decodable {
+    let id: Int
+    let content: String
+    let author: String
+    let likeCount: Int
+    let complaintCount: Int
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,9 @@
+# iOS Client for First Program
+
+This folder contains a basic SwiftUI application that can communicate with the existing Flask backend. It provides a skeleton implementation of login, todo list, and forum features.
+
+## Building
+
+Open the folder in Xcode and create a new project using the existing Swift files. Configure the `baseURL` in `ApiService.swift` to point to your deployed backend.
+
+Run the project on an iOS device or simulator.


### PR DESCRIPTION
## Summary
- add SwiftUI iOS client skeleton under `ios-app`

## Testing
- `python -m py_compile app.py models.py wsgi.py`
- `swiftc -o /tmp/test ios-app/FirstProgramApp.swift ios-app/ContentView.swift ios-app/Models.swift ios-app/ApiService.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685ac8b012b483318cac39d6cd82ba97